### PR TITLE
Fix docs and copy listener, drop tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BashDatDash is a lightweight Chrome extension designed to enhance your ChatGPT e
 
 - **Automatic Dash Replacement:** Replaces em-dashes and/or en-dashes in streamed and initial ChatGPT text.
 - **Clipboard Integration:** Modifies copied text to reflect your chosen dash replacements.
-- **Customizable Settings:** Easily configure dash types to replace and the replacement string via a simple popup UI.
+- **Customizable Settings:** Easily configure **which** dash types to replace and the replacement string via a simple popup UI.
 - **Zero Overhead When Disabled:** The extension consumes no measurable runtime resources when turned off.
 
 ## Installation
@@ -18,7 +18,7 @@ BashDatDash is a lightweight Chrome extension designed to enhance your ChatGPT e
 
 ## Usage
 
-Once installed, BashDatDash will automatically activate on `chat.openai.com`. You can customize its behavior by clicking the extension icon in your Chrome toolbar. The popup will allow you to:
+Once installed, BashDatDash will automatically activate on `chatgpt.com`. You can customize its behavior by clicking the extension icon in your Chrome toolbar. The popup will allow you to:
 
 - Enable or disable the extension.
 - Choose whether to replace em-dashes, en-dashes, or both.

--- a/content.js
+++ b/content.js
@@ -22,6 +22,7 @@
 
   let chatRootObserver = null; // Declare observer globally for management
   let copyListenerAttached = false; // Track clipboard listener state
+  let copyButtonListenerAttached = false; // Track ChatGPT copy button listener state
 
   logDebug("Settings retrieved:", { enabled, replaceWhat, storedReplaceWith: replaceWith, effectiveReplacement: replacement, onboardingShown });
 
@@ -75,7 +76,10 @@
         }
       }
       // Attach delegated listener for ChatGPT's copy buttons to document.body, regardless of chatRoot
-      attachChatGPTCopyButtonDelegatedListener();
+      if (!copyButtonListenerAttached) {
+        attachChatGPTCopyButtonDelegatedListener();
+        copyButtonListenerAttached = true;
+      }
 
     } else {
       logDebug("Deactivating extension features.");
@@ -88,7 +92,10 @@
         copyListenerAttached = false;
       }
       // Remove delegated listener for ChatGPT's copy buttons from document.body
-      removeChatGPTCopyButtonDelegatedListener();
+      if (copyButtonListenerAttached) {
+        removeChatGPTCopyButtonDelegatedListener();
+        copyButtonListenerAttached = false;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- clarify README customization bullet
- update site domain
- track delegated copy-button listener in `content.js`
- remove Node test code and automated tests

## Testing
- no tests included


------
https://chatgpt.com/codex/tasks/task_e_685cc2548f50832cb152bf8a64116086