### PR TITLE
Modernize settings UI

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -1,32 +1,94 @@
 body {
-  font-family: sans-serif;
-  padding: 10px;
-  width: 250px;
+  font-family: Arial, sans-serif;
+  background-color: #f9f9f9;
+  padding: 15px;
+  width: 260px;
 }
 
-label {
+.toggle-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .2s;
+  border-radius: 34px;
+}
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  transition: .2s;
+  border-radius: 50%;
+}
+.switch input:checked + .slider {
+  background-color: #4caf50;
+}
+.switch input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
+.option-group {
+  margin-bottom: 15px;
+}
+.option-group label {
+  font-weight: bold;
+  margin-bottom: 5px;
   display: block;
-  margin: 10px 0 5px;
+}
+.checkbox-item {
+  display: flex;
+  align-items: center;
+  margin: 3px 0;
+}
+.checkbox-item input {
+  margin-right: 6px;
 }
 
-select, input[type=checkbox] {
+select {
   width: 100%;
+  padding: 4px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
 }
 
 .footer {
-  margin-top: 15px;
+  margin-top: 20px;
   text-align: center;
   font-size: 0.9em;
 }
 
-/* Style for the Buy Me a Coffee button */
 #buyCoffee {
   display: inline-block;
-  background-color: #40DCA5; /* A pleasant green */
+  background-color: #40DCA5;
   color: #fff;
-  font-family: 'Cookie', cursive; /* Example font, ensure it's available or use a web-safe alternative */
+  font-family: 'Cookie', cursive;
   font-size: 14px;
   padding: 6px 10px;
   border-radius: 5px;
   text-decoration: none;
-} 
+}

--- a/popup.html
+++ b/popup.html
@@ -5,24 +5,41 @@
   <link rel="stylesheet" href="popup.css">
 </head>
 <body>
-  <label>
-    <input type="checkbox" id="toggleEnabled">
-    Enable BashDatDash
-  </label>
+  <div class="toggle-container">
+    <span>Enable BashDatDash</span>
+    <label class="switch">
+      <input type="checkbox" id="toggleEnabled">
+      <span class="slider"></span>
+    </label>
+  </div>
 
-  <label for="replaceWhat">Replace:</label>
-  <select id="replaceWhat">
-    <option value="em">Em dash (—)</option>
-    <option value="en">En dash (–)</option>
-    <option value="both" selected>Both</option>
-  </select>
+  <div class="option-group">
+    <label>Replace:</label>
+    <div class="checkbox-item">
+      <input type="checkbox" id="replaceEm">
+      <span>Em dash (—)</span>
+    </div>
+    <div class="checkbox-item">
+      <input type="checkbox" id="replaceEn">
+      <span>En dash (–)</span>
+    </div>
+  </div>
 
-  <label for="replaceWith">Replace with:</label>
-  <select id="replaceWith">
-    <option value=", ">Comma + space (, )</option>
-    <option value="; ">Semicolon + space (; )</option>
-    <option value="--">Double hyphen (--)</option>
-  </select>
+  <div class="option-group" id="replaceWithGroup">
+    <label>Replace with:</label>
+    <div class="checkbox-item">
+      <input type="checkbox" id="replaceComma" value=", " name="replaceWithOption">
+      <span>Comma + space (, )</span>
+    </div>
+    <div class="checkbox-item">
+      <input type="checkbox" id="replaceSemi" value="; " name="replaceWithOption">
+      <span>Semicolon + space (; )</span>
+    </div>
+    <div class="checkbox-item">
+      <input type="checkbox" id="replaceDoubleHyphen" value="--" name="replaceWithOption">
+      <span>Double hyphen (--)</span>
+    </div>
+  </div>
 
   <div class="footer">
     <a id="buyCoffee" href="https://coff.ee/brownjason1" target="_blank" rel="noopener noreferrer"

--- a/popup.js
+++ b/popup.js
@@ -6,8 +6,29 @@ chrome.storage.sync.get(['enabled', 'replaceWhat', 'replaceWith'], (data) => {
   const initialReplaceWith = validReplaceWith.includes(data.replaceWith) ? data.replaceWith : ', ';
 
   document.getElementById('toggleEnabled').checked = initialEnabled;
-  document.getElementById('replaceWhat').value = initialReplaceWhat;
-  document.getElementById('replaceWith').value = initialReplaceWith;
+
+  const replaceEm = document.getElementById('replaceEm');
+  const replaceEn = document.getElementById('replaceEn');
+  const replaceComma = document.getElementById('replaceComma');
+  const replaceSemi = document.getElementById('replaceSemi');
+  const replaceDoubleHyphen = document.getElementById('replaceDoubleHyphen');
+
+  if (initialReplaceWhat === 'both') {
+    replaceEm.checked = true;
+    replaceEn.checked = true;
+  } else if (initialReplaceWhat === 'en') {
+    replaceEn.checked = true;
+  } else {
+    replaceEm.checked = true;
+  }
+
+  if (initialReplaceWith === '; ') {
+    replaceSemi.checked = true;
+  } else if (initialReplaceWith === '--') {
+    replaceDoubleHyphen.checked = true;
+  } else {
+    replaceComma.checked = true;
+  }
 
   // Save defaults to storage if they were undefined
   chrome.storage.sync.set({
@@ -31,26 +52,63 @@ document.getElementById('toggleEnabled').addEventListener('change', (e) => {
   });
 });
 
-document.getElementById('replaceWhat').addEventListener('change', (e) => {
-  chrome.storage.sync.set({ replaceWhat: e.target.value });
-  // Send message to content script about the new replaceWhat value
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    if (tabs[0] && tabs[0].id) {
-      chrome.tabs.sendMessage(tabs[0].id, { type: 'SETTINGS_UPDATED', replaceWhat: e.target.value }).catch(() => {
-        console.log("BashDatDash: Content script not found or not ready to receive message.");
-      });
-    }
-  });
-});
+function updateReplaceWhat(e) {
+  const replaceEm = document.getElementById('replaceEm');
+  const replaceEn = document.getElementById('replaceEn');
+  const em = replaceEm.checked;
+  const en = replaceEn.checked;
 
-document.getElementById('replaceWith').addEventListener('change', (e) => {
-  chrome.storage.sync.set({ replaceWith: e.target.value });
-  // Send message to content script about the new replaceWith value
+  if (!em && !en) {
+    // prevent deselecting all options
+    e.target.checked = true;
+    return;
+  }
+
+  let value = 'em';
+  if (em && en) {
+    value = 'both';
+  } else if (en && !em) {
+    value = 'en';
+  }
+
+  chrome.storage.sync.set({ replaceWhat: value });
+
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (tabs[0] && tabs[0].id) {
-      chrome.tabs.sendMessage(tabs[0].id, { type: 'SETTINGS_UPDATED', replaceWith: e.target.value }).catch(() => {
+      chrome.tabs.sendMessage(tabs[0].id, { type: 'SETTINGS_UPDATED', replaceWhat: value }).catch(() => {
         console.log("BashDatDash: Content script not found or not ready to receive message.");
       });
     }
   });
-});
+}
+
+document.getElementById('replaceEm').addEventListener('change', updateReplaceWhat);
+document.getElementById('replaceEn').addEventListener('change', updateReplaceWhat);
+
+function updateReplaceWith(target) {
+  const options = Array.from(document.querySelectorAll('input[name="replaceWithOption"]'));
+
+  if (target.checked) {
+    options.forEach(cb => { if (cb !== target) cb.checked = false; });
+  } else if (!options.some(cb => cb.checked)) {
+    // prevent having none selected
+    target.checked = true;
+    return;
+  }
+
+  const checked = options.find(cb => cb.checked) || target;
+  const value = checked.value;
+
+  chrome.storage.sync.set({ replaceWith: value });
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (tabs[0] && tabs[0].id) {
+      chrome.tabs.sendMessage(tabs[0].id, { type: 'SETTINGS_UPDATED', replaceWith: value }).catch(() => {
+        console.log("BashDatDash: Content script not found or not ready to receive message.");
+      });
+    }
+  });
+}
+
+document.getElementById('replaceComma').addEventListener('change', (e) => updateReplaceWith(e.target));
+document.getElementById('replaceSemi').addEventListener('change', (e) => updateReplaceWith(e.target));
+document.getElementById('replaceDoubleHyphen').addEventListener('change', (e) => updateReplaceWith(e.target));


### PR DESCRIPTION
## Summary
- restyle popup with modern toggle switch and option groups
- convert dash replacement selector from dropdown to checkboxes
- switch replacement string selector to checkboxes and ensure at least one choice in each group
- update popup logic to enforce at least one selection and removed `none` option
- simplify content script dash pattern map

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685cc5045438832ca0ac0a635ce79f2b