### PR TITLE
Add dynamic preview carousel

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -92,3 +92,29 @@ select {
   border-radius: 5px;
   text-decoration: none;
 }
+
+#previewSection {
+  border-top: 1px solid #ccc;
+  margin-top: 10px;
+  padding-top: 10px;
+}
+
+.preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 5px;
+}
+
+.carousel-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 4px;
+}
+
+#beforeSentence,
+#afterSentence {
+  margin: 2px 0;
+}

--- a/popup.html
+++ b/popup.html
@@ -41,6 +41,16 @@
     </div>
   </div>
 
+  <div id="previewSection">
+    <div class="preview-header">
+      <button id="prevExample" class="carousel-btn">&#8249;</button>
+      <span id="exampleCounter"></span>
+      <button id="nextExample" class="carousel-btn">&#8250;</button>
+    </div>
+    <p><strong>Before:</strong> <span id="beforeSentence"></span></p>
+    <p><strong>After:</strong> <span id="afterSentence"></span></p>
+  </div>
+
   <div class="footer">
     <a id="buyCoffee" href="https://coff.ee/brownjason1" target="_blank" rel="noopener noreferrer"
       style="display:inline-block; background-color:#40DCA5; color:#fff; font-family:Cookie, cursive; font-size:14px; padding:6px 10px; border-radius:5px; text-decoration:none;">

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,45 @@
+let replaceEm, replaceEn, replaceComma, replaceSemi, replaceDoubleHyphen;
+let exampleCounter, beforeSentence, afterSentence;
+
+const examples = [
+  'The quick\u2014brown\u2014fox jumps over the lazy dog.',
+  'An up\u2013to\u2013date record\u2014like this\u2014works well.',
+  'She paused\u2014thinking\u2014before speaking.',
+  'Using dashes\u2014such as these\u2014can be tricky.'
+];
+let currentExample = 0;
+
+function applyReplacement(text) {
+  const replaceWith = document.querySelector('input[name="replaceWithOption"]:checked').value;
+  let result = text;
+  if (replaceEm && replaceEm.checked) {
+    result = result.replace(/\u2014/g, replaceWith);
+  }
+  if (replaceEn && replaceEn.checked) {
+    result = result.replace(/\u2013/g, replaceWith);
+  }
+  return result;
+}
+
+function updatePreview() {
+  if (!exampleCounter) return;
+  const total = examples.length;
+  exampleCounter.textContent = `${currentExample + 1}/${total}`;
+  const before = examples[currentExample];
+  beforeSentence.textContent = before;
+  afterSentence.textContent = applyReplacement(before);
+}
+
+document.getElementById('prevExample').addEventListener('click', () => {
+  currentExample = (currentExample - 1 + examples.length) % examples.length;
+  updatePreview();
+});
+
+document.getElementById('nextExample').addEventListener('click', () => {
+  currentExample = (currentExample + 1) % examples.length;
+  updatePreview();
+});
+
 chrome.storage.sync.get(['enabled', 'replaceWhat', 'replaceWith'], (data) => {
   // Set default values if not already present in storage
   const initialEnabled = data.enabled ?? true;
@@ -7,11 +49,14 @@ chrome.storage.sync.get(['enabled', 'replaceWhat', 'replaceWith'], (data) => {
 
   document.getElementById('toggleEnabled').checked = initialEnabled;
 
-  const replaceEm = document.getElementById('replaceEm');
-  const replaceEn = document.getElementById('replaceEn');
-  const replaceComma = document.getElementById('replaceComma');
-  const replaceSemi = document.getElementById('replaceSemi');
-  const replaceDoubleHyphen = document.getElementById('replaceDoubleHyphen');
+  replaceEm = document.getElementById('replaceEm');
+  replaceEn = document.getElementById('replaceEn');
+  replaceComma = document.getElementById('replaceComma');
+  replaceSemi = document.getElementById('replaceSemi');
+  replaceDoubleHyphen = document.getElementById('replaceDoubleHyphen');
+  exampleCounter = document.getElementById('exampleCounter');
+  beforeSentence = document.getElementById('beforeSentence');
+  afterSentence = document.getElementById('afterSentence');
 
   if (initialReplaceWhat === 'both') {
     replaceEm.checked = true;
@@ -36,6 +81,8 @@ chrome.storage.sync.get(['enabled', 'replaceWhat', 'replaceWith'], (data) => {
     replaceWhat: initialReplaceWhat,
     replaceWith: initialReplaceWith
   });
+
+  updatePreview();
 });
 
 document.getElementById('toggleEnabled').addEventListener('change', (e) => {
@@ -53,8 +100,6 @@ document.getElementById('toggleEnabled').addEventListener('change', (e) => {
 });
 
 function updateReplaceWhat(e) {
-  const replaceEm = document.getElementById('replaceEm');
-  const replaceEn = document.getElementById('replaceEn');
   const em = replaceEm.checked;
   const en = replaceEn.checked;
 
@@ -80,6 +125,8 @@ function updateReplaceWhat(e) {
       });
     }
   });
+
+  updatePreview();
 }
 
 document.getElementById('replaceEm').addEventListener('change', updateReplaceWhat);
@@ -107,6 +154,8 @@ function updateReplaceWith(target) {
       });
     }
   });
+
+  updatePreview();
 }
 
 document.getElementById('replaceComma').addEventListener('change', (e) => updateReplaceWith(e.target));


### PR DESCRIPTION
## Summary
- add preview carousel to settings page
- show before/after text that updates with settings
- include basic styles and JS logic for preview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ccfa38954832c85779e22c90e0b26